### PR TITLE
Add test suite covering URL parsing, HTTP routing, input validation, and cleanup logic

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -5,6 +5,7 @@
   "importMap": "import_map.json",
   "tasks": {
     "start": "deno run --allow-net --allow-write --allow-read --allow-run --allow-env --import-map=import_map.json webcam-snapshot.ts",
+    "test": "deno test --allow-net --allow-write --allow-read --allow-run --allow-env --import-map=import_map.json",
     "docker-build": "docker build -t webcam-snapshot . ",
     "docker-run": "docker run -p 3000:3000 -e PORT=3000 -e PUBLIC_URL=http://localhost:3000 webcam-snapshot",
     "docker-all": "deno task docker-build && deno task docker-run"

--- a/webcam-snapshot_test.ts
+++ b/webcam-snapshot_test.ts
@@ -1,0 +1,168 @@
+/// <reference lib="deno.ns" />
+
+import { assertEquals, assertStringIncludes } from "std/assert/mod.ts";
+import {
+    cleanupOldSnapshots,
+    handleWebcamRequest,
+} from "./webcam-snapshot.ts";
+
+// ---------------------------------------------------------------------------
+// handleWebcamRequest – routing and input validation (no ffmpeg required)
+// ---------------------------------------------------------------------------
+
+Deno.test("handleWebcamRequest: default route returns 200 with help text", async () => {
+    const req = new Request("http://localhost:3000/");
+    const res = await handleWebcamRequest(req);
+    assertEquals(res.status, 200);
+    const body = await res.text();
+    assertStringIncludes(body, "Webcam Snapshot Service");
+});
+
+Deno.test("handleWebcamRequest: default route has text/plain Content-Type", async () => {
+    const req = new Request("http://localhost:3000/");
+    const res = await handleWebcamRequest(req);
+    assertEquals(res.headers.get("Content-Type"), "text/plain");
+});
+
+Deno.test("handleWebcamRequest: /snapshot without url returns 400", async () => {
+    const req = new Request("http://localhost:3000/snapshot");
+    const res = await handleWebcamRequest(req);
+    assertEquals(res.status, 400);
+});
+
+Deno.test("handleWebcamRequest: /redirect without url returns 400", async () => {
+    const req = new Request("http://localhost:3000/redirect");
+    const res = await handleWebcamRequest(req);
+    assertEquals(res.status, 400);
+});
+
+Deno.test("handleWebcamRequest: /redirect with invalid format returns 400", async () => {
+    const req = new Request(
+        "http://localhost:3000/redirect?url=https://example.com/stream.m3u8&format=mp4",
+    );
+    const res = await handleWebcamRequest(req);
+    assertEquals(res.status, 400);
+});
+
+Deno.test("handleWebcamRequest: /redirect accepts jpg format (fails at ffmpeg, not validation)", async () => {
+    // Validation passes – the 500 comes from ffmpeg failing on an invalid stream URL.
+    // This confirms format='jpg' is accepted as valid input.
+    const req = new Request(
+        "http://localhost:3000/redirect?url=https://invalid-stream.example.com/nonexistent.m3u8&format=jpg",
+    );
+    const res = await handleWebcamRequest(req);
+    // Should NOT be 400 (bad request) – validation passed
+    const status = res.status;
+    assertEquals(status !== 400, true, `Expected non-400 status, got ${status}`);
+});
+
+Deno.test("handleWebcamRequest: /redirect accepts gif format (fails at ffmpeg, not validation)", async () => {
+    const req = new Request(
+        "http://localhost:3000/redirect?url=https://invalid-stream.example.com/nonexistent.m3u8&format=gif",
+    );
+    const res = await handleWebcamRequest(req);
+    assertEquals(res.status !== 400, true);
+});
+
+Deno.test("handleWebcamRequest: /images/ for missing file returns 404", async () => {
+    const req = new Request(
+        "http://localhost:3000/images/definitely-does-not-exist-snapshot.jpg",
+    );
+    const res = await handleWebcamRequest(req);
+    assertEquals(res.status, 404);
+});
+
+Deno.test("handleWebcamRequest: /images/ .gif file gets image/gif Content-Type", async () => {
+    // Write a tiny placeholder gif so we can test content-type resolution
+    const dir = "snapshots";
+    const filename = "snapshot-test-contenttype.gif";
+    await Deno.mkdir(dir, { recursive: true });
+    await Deno.writeFile(`${dir}/${filename}`, new Uint8Array([0x47, 0x49, 0x46]));
+
+    const req = new Request(`http://localhost:3000/images/${filename}`);
+    const res = await handleWebcamRequest(req);
+
+    await Deno.remove(`${dir}/${filename}`);
+
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get("Content-Type"), "image/gif");
+});
+
+Deno.test("handleWebcamRequest: /images/ .jpg file gets image/jpeg Content-Type", async () => {
+    const dir = "snapshots";
+    const filename = "snapshot-test-contenttype.jpg";
+    await Deno.mkdir(dir, { recursive: true });
+    await Deno.writeFile(`${dir}/${filename}`, new Uint8Array([0xff, 0xd8, 0xff]));
+
+    const req = new Request(`http://localhost:3000/images/${filename}`);
+    const res = await handleWebcamRequest(req);
+
+    await Deno.remove(`${dir}/${filename}`);
+
+    assertEquals(res.status, 200);
+    assertEquals(res.headers.get("Content-Type"), "image/jpeg");
+});
+
+// ---------------------------------------------------------------------------
+// cleanupOldSnapshots – file-system behaviour (uses real snapshots dir)
+// ---------------------------------------------------------------------------
+
+Deno.test(
+    "cleanupOldSnapshots: removes files beyond the 100-file limit",
+    { permissions: { read: true, write: true } },
+    async () => {
+        const dir = "snapshots";
+        await Deno.mkdir(dir, { recursive: true });
+
+        // Create 105 dummy snapshot files
+        for (let i = 0; i < 105; i++) {
+            const name = `snapshot-test-cleanup-${String(i).padStart(4, "0")}.jpg`;
+            await Deno.writeFile(`${dir}/${name}`, new Uint8Array([0xff, 0xd8]));
+        }
+
+        await cleanupOldSnapshots();
+
+        let remaining = 0;
+        for await (const entry of Deno.readDir(dir)) {
+            if (entry.name.startsWith("snapshot-test-cleanup-")) remaining++;
+        }
+
+        // Clean up survivors
+        for await (const entry of Deno.readDir(dir)) {
+            if (entry.name.startsWith("snapshot-test-cleanup-")) {
+                await Deno.remove(`${dir}/${entry.name}`);
+            }
+        }
+
+        assertEquals(remaining, 100);
+    },
+);
+
+Deno.test(
+    "cleanupOldSnapshots: does not remove files when under the 100-file limit",
+    { permissions: { read: true, write: true } },
+    async () => {
+        const dir = "snapshots";
+        await Deno.mkdir(dir, { recursive: true });
+
+        for (let i = 0; i < 10; i++) {
+            const name = `snapshot-test-keep-${String(i).padStart(4, "0")}.jpg`;
+            await Deno.writeFile(`${dir}/${name}`, new Uint8Array([0xff, 0xd8]));
+        }
+
+        await cleanupOldSnapshots();
+
+        let remaining = 0;
+        for await (const entry of Deno.readDir(dir)) {
+            if (entry.name.startsWith("snapshot-test-keep-")) remaining++;
+        }
+
+        for await (const entry of Deno.readDir(dir)) {
+            if (entry.name.startsWith("snapshot-test-keep-")) {
+                await Deno.remove(`${dir}/${entry.name}`);
+            }
+        }
+
+        assertEquals(remaining, 10);
+    },
+);

--- a/youtube-snapshot.ts
+++ b/youtube-snapshot.ts
@@ -22,7 +22,7 @@ try {
 }
 
 // Function to extract video ID from YouTube URL
-function extractYouTubeVideoId(url: string): string | null {
+export function extractYouTubeVideoId(url: string): string | null {
     const patterns = [
         /(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\n?#]+)/,
         /youtube\.com\/embed\/([^&\n?#]+)/,
@@ -214,7 +214,7 @@ async function getYouTubeThumbnail(videoId: string, timestamp: string): Promise<
 }
 
 // Clean up old snapshots (keep last 100)
-async function cleanupOldSnapshots() {
+export async function cleanupOldSnapshots() {
     try {
         const files = [];
         for await (const entry of Deno.readDir(SNAPSHOTS_DIR)) {

--- a/youtube-snapshot_test.ts
+++ b/youtube-snapshot_test.ts
@@ -1,0 +1,263 @@
+/// <reference lib="deno.ns" />
+
+import { assertEquals, assertStringIncludes } from "std/assert/mod.ts";
+import {
+    extractYouTubeVideoId,
+    cleanupOldSnapshots,
+    handleYouTubeSnapshot,
+} from "./youtube-snapshot.ts";
+
+// ---------------------------------------------------------------------------
+// extractYouTubeVideoId – pure function, no side-effects
+// ---------------------------------------------------------------------------
+
+Deno.test("extractYouTubeVideoId: standard watch URL", () => {
+    assertEquals(
+        extractYouTubeVideoId("https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+        "dQw4w9WgXcQ",
+    );
+});
+
+Deno.test("extractYouTubeVideoId: watch URL with extra query parameters", () => {
+    assertEquals(
+        extractYouTubeVideoId(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s&list=PL123",
+        ),
+        "dQw4w9WgXcQ",
+    );
+});
+
+Deno.test("extractYouTubeVideoId: short youtu.be URL", () => {
+    assertEquals(
+        extractYouTubeVideoId("https://youtu.be/dQw4w9WgXcQ"),
+        "dQw4w9WgXcQ",
+    );
+});
+
+Deno.test("extractYouTubeVideoId: embed URL", () => {
+    assertEquals(
+        extractYouTubeVideoId("https://www.youtube.com/embed/dQw4w9WgXcQ"),
+        "dQw4w9WgXcQ",
+    );
+});
+
+Deno.test("extractYouTubeVideoId: live youtu.be URL", () => {
+    assertEquals(
+        extractYouTubeVideoId("https://youtu.be/live_XYZ123abc"),
+        "live_XYZ123abc",
+    );
+});
+
+Deno.test("extractYouTubeVideoId: non-YouTube URL returns null", () => {
+    assertEquals(
+        extractYouTubeVideoId("https://vimeo.com/123456789"),
+        null,
+    );
+});
+
+Deno.test("extractYouTubeVideoId: empty string returns null", () => {
+    assertEquals(extractYouTubeVideoId(""), null);
+});
+
+Deno.test("extractYouTubeVideoId: plain text returns null", () => {
+    assertEquals(extractYouTubeVideoId("not-a-url"), null);
+});
+
+Deno.test("extractYouTubeVideoId: URL missing video ID returns null", () => {
+    assertEquals(
+        extractYouTubeVideoId("https://www.youtube.com/watch"),
+        null,
+    );
+});
+
+// ---------------------------------------------------------------------------
+// handleYouTubeSnapshot – input validation (no ffmpeg/network required)
+// ---------------------------------------------------------------------------
+
+Deno.test("handleYouTubeSnapshot: /youtube-snapshot without url returns 400", async () => {
+    const req = new Request("http://localhost:3000/youtube-snapshot");
+    const res = await handleYouTubeSnapshot(req);
+    assertEquals(res.status, 400);
+});
+
+Deno.test("handleYouTubeSnapshot: /youtube-snapshot/redirect without url returns 400", async () => {
+    const req = new Request("http://localhost:3000/youtube-snapshot/redirect");
+    const res = await handleYouTubeSnapshot(req);
+    assertEquals(res.status, 400);
+});
+
+Deno.test("handleYouTubeSnapshot: /youtube-snapshot/redirect with invalid format returns 400", async () => {
+    const req = new Request(
+        "http://localhost:3000/youtube-snapshot/redirect?url=https://youtube.com/watch%3Fv%3Dabc&format=mp4",
+    );
+    const res = await handleYouTubeSnapshot(req);
+    assertEquals(res.status, 400);
+});
+
+Deno.test("handleYouTubeSnapshot: /youtube-snapshot with non-YouTube URL returns 500 with error body", async () => {
+    // extractYouTubeVideoId returns null → thrown before any network call
+    const req = new Request(
+        "http://localhost:3000/youtube-snapshot?url=https://not-youtube.com/video",
+    );
+    const res = await handleYouTubeSnapshot(req);
+    assertEquals(res.status, 500);
+    const body = await res.json();
+    assertEquals(body.error, "Invalid YouTube URL");
+});
+
+Deno.test("handleYouTubeSnapshot: /youtube-snapshot error response has JSON Content-Type", async () => {
+    const req = new Request(
+        "http://localhost:3000/youtube-snapshot?url=https://not-youtube.com",
+    );
+    const res = await handleYouTubeSnapshot(req);
+    assertEquals(res.headers.get("Content-Type"), "application/json");
+});
+
+Deno.test("handleYouTubeSnapshot: /youtube-snapshot/redirect with non-YouTube URL returns 500", async () => {
+    const req = new Request(
+        "http://localhost:3000/youtube-snapshot/redirect?url=https://not-youtube.com&format=jpg",
+    );
+    const res = await handleYouTubeSnapshot(req);
+    assertEquals(res.status, 500);
+});
+
+Deno.test("handleYouTubeSnapshot: /youtube-snapshot/images/ for missing file returns 404", async () => {
+    const req = new Request(
+        "http://localhost:3000/youtube-snapshot/images/definitely-does-not-exist-12345.jpg",
+    );
+    const res = await handleYouTubeSnapshot(req);
+    assertEquals(res.status, 404);
+});
+
+Deno.test("handleYouTubeSnapshot: unknown sub-path returns 404", async () => {
+    const req = new Request(
+        "http://localhost:3000/youtube-snapshot/unknown-path",
+    );
+    const res = await handleYouTubeSnapshot(req);
+    assertEquals(res.status, 404);
+});
+
+Deno.test("handleYouTubeSnapshot: /youtube-snapshot/ returns help text with 200", async () => {
+    const req = new Request("http://localhost:3000/youtube-snapshot/");
+    const res = await handleYouTubeSnapshot(req);
+    assertEquals(res.status, 200);
+    const body = await res.text();
+    assertStringIncludes(body, "YouTube Snapshot Service");
+});
+
+// ---------------------------------------------------------------------------
+// cleanupOldSnapshots – file-system behaviour (uses real youtube-snapshots dir)
+// ---------------------------------------------------------------------------
+
+Deno.test(
+    "cleanupOldSnapshots: removes files beyond the 100-file limit",
+    { permissions: { read: true, write: true } },
+    async () => {
+        const dir = "youtube-snapshots";
+        // Ensure directory exists
+        await Deno.mkdir(dir, { recursive: true });
+
+        // Create 105 dummy snapshot files
+        const created: string[] = [];
+        for (let i = 0; i < 105; i++) {
+            const name = `youtube-test-cleanup-${String(i).padStart(4, "0")}.jpg`;
+            const path = `${dir}/${name}`;
+            await Deno.writeFile(path, new Uint8Array([0xff, 0xd8]));
+            created.push(name);
+        }
+
+        await cleanupOldSnapshots();
+
+        // Count remaining test files
+        let remaining = 0;
+        for await (const entry of Deno.readDir(dir)) {
+            if (entry.name.startsWith("youtube-test-cleanup-")) remaining++;
+        }
+
+        // Clean up what is left
+        for await (const entry of Deno.readDir(dir)) {
+            if (entry.name.startsWith("youtube-test-cleanup-")) {
+                await Deno.remove(`${dir}/${entry.name}`);
+            }
+        }
+
+        // The cleanup keeps the latest 100; 5 of our 105 files should be gone
+        assertEquals(remaining, 100);
+    },
+);
+
+Deno.test(
+    "cleanupOldSnapshots: does not remove files when under the 100-file limit",
+    { permissions: { read: true, write: true } },
+    async () => {
+        const dir = "youtube-snapshots";
+        await Deno.mkdir(dir, { recursive: true });
+
+        // Create only 10 files – all should survive
+        const created: string[] = [];
+        for (let i = 0; i < 10; i++) {
+            const name = `youtube-test-keep-${String(i).padStart(4, "0")}.jpg`;
+            const path = `${dir}/${name}`;
+            await Deno.writeFile(path, new Uint8Array([0xff, 0xd8]));
+            created.push(name);
+        }
+
+        await cleanupOldSnapshots();
+
+        let remaining = 0;
+        for await (const entry of Deno.readDir(dir)) {
+            if (entry.name.startsWith("youtube-test-keep-")) remaining++;
+        }
+
+        // Clean up
+        for await (const entry of Deno.readDir(dir)) {
+            if (entry.name.startsWith("youtube-test-keep-")) {
+                await Deno.remove(`${dir}/${entry.name}`);
+            }
+        }
+
+        assertEquals(remaining, 10);
+    },
+);
+
+Deno.test(
+    "cleanupOldSnapshots: only removes files with youtube- prefix",
+    { permissions: { read: true, write: true } },
+    async () => {
+        const dir = "youtube-snapshots";
+        await Deno.mkdir(dir, { recursive: true });
+
+        // Create files with a non-matching prefix – should never be touched
+        const unrelated = `${dir}/snapshot-should-survive.jpg`;
+        await Deno.writeFile(unrelated, new Uint8Array([0xff, 0xd8]));
+
+        // Create 105 youtube- prefixed files to trigger cleanup
+        for (let i = 0; i < 105; i++) {
+            const name = `youtube-test-prefix-${String(i).padStart(4, "0")}.jpg`;
+            await Deno.writeFile(`${dir}/${name}`, new Uint8Array([0xff, 0xd8]));
+        }
+
+        await cleanupOldSnapshots();
+
+        // Verify the unrelated file is still present
+        let survives = false;
+        try {
+            await Deno.stat(unrelated);
+            survives = true;
+        } catch {
+            survives = false;
+        }
+
+        // Clean up all test files
+        for await (const entry of Deno.readDir(dir)) {
+            if (
+                entry.name.startsWith("youtube-test-prefix-") ||
+                entry.name === "snapshot-should-survive.jpg"
+            ) {
+                await Deno.remove(`${dir}/${entry.name}`);
+            }
+        }
+
+        assertEquals(survives, true);
+    },
+);


### PR DESCRIPTION
- Export `extractYouTubeVideoId` and `cleanupOldSnapshots` from youtube-snapshot.ts
  so they can be imported by test files without side-effects
- Refactor webcam-snapshot.ts: extract the inline Deno.serve handler into an exported
  `handleWebcamRequest` function and guard server startup with `import.meta.main`,
  enabling unit tests to import the module without starting a live server
- Export `cleanupOldSnapshots` from webcam-snapshot.ts
- Add youtube-snapshot_test.ts with 20 tests covering:
  - extractYouTubeVideoId with standard/short/embed/edge-case URLs
  - handleYouTubeSnapshot input validation (400/404/500 responses)
  - cleanupOldSnapshots file-system behaviour (>100, <100, prefix filtering)
- Add webcam-snapshot_test.ts with 12 tests covering:
  - handleWebcamRequest routing and default help text
  - /snapshot and /redirect input validation (missing url, invalid format)
  - /images/ content-type resolution (image/gif vs image/jpeg)
  - cleanupOldSnapshots file-system behaviour
- Add `test` task to deno.json: `deno test` with matching permission flags

https://claude.ai/code/session_0111q5Q2uvHNKHuupKrTW8YL