### PR TITLE
Fix yt-dlp binary download URL for Linux compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM denoland/deno:latest
 
-# Install ffmpeg and yt-dlp
+# TARGETARCH is provided automatically by Docker BuildKit (amd64, arm64, etc.)
+ARG TARGETARCH
+
+# Install ffmpeg and yt-dlp (select the correct binary for the target architecture)
 RUN apt-get update && \
     apt-get install -y ffmpeg curl && \
-    curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux -o /usr/local/bin/yt-dlp && \
+    YTDLP_BINARY=$([ "$TARGETARCH" = "arm64" ] && echo "yt-dlp_linux_aarch64" || echo "yt-dlp_linux") && \
+    curl -fSL https://github.com/yt-dlp/yt-dlp/releases/latest/download/${YTDLP_BINARY} -o /usr/local/bin/yt-dlp --retry 3 --retry-delay 5 && \
     chmod a+rx /usr/local/bin/yt-dlp && \
     apt-get clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM denoland/deno:latest
 # Install ffmpeg and yt-dlp
 RUN apt-get update && \
     apt-get install -y ffmpeg curl && \
-    curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp && \
+    curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux -o /usr/local/bin/yt-dlp && \
     chmod a+rx /usr/local/bin/yt-dlp && \
     apt-get clean
 


### PR DESCRIPTION
## Summary
Updated the yt-dlp installation in the Dockerfile to download the correct Linux-specific binary instead of a generic release artifact.

## Changes
- Modified the yt-dlp download URL from `yt-dlp` to `yt-dlp_linux` to ensure the correct executable binary is downloaded for Linux environments
- This resolves potential compatibility issues when running the container on Linux systems

## Details
The original download URL was pointing to a generic `yt-dlp` artifact which may not be the correct executable format for Linux. By explicitly downloading `yt-dlp_linux`, we ensure the proper Linux binary is installed in the container, improving reliability and compatibility.

https://claude.ai/code/session_01BJHEYkKbFLETytMunGhzSC