### PR TITLE
Add YouTube cookies support and improve thumbnail fallback logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,5 +31,9 @@ RUN deno cache --import-map=import_map.json webcam-snapshot.ts
 RUN mkdir snapshots
 RUN mkdir youtube-snapshots
 
+# Optional: mount a cookies file at /app/cookies.txt for YouTube authentication
+# Use: docker run -v /path/to/cookies.txt:/app/cookies.txt -e YT_COOKIES_FILE=/app/cookies.txt ...
+ENV YT_COOKIES_FILE=""
+
 # Start the application
 CMD ["deno", "task", "start"] 

--- a/youtube-snapshot.test.ts
+++ b/youtube-snapshot.test.ts
@@ -1,5 +1,5 @@
-import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
-import { extractYouTubeVideoId } from "./youtube-snapshot.ts";
+import { assertEquals, assertRejects } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import { extractYouTubeVideoId, getYouTubeThumbnail } from "./youtube-snapshot.ts";
 
 Deno.test("extractYouTubeVideoId - watch URL", () => {
   assertEquals(
@@ -39,4 +39,83 @@ Deno.test("extractYouTubeVideoId - empty string returns null", () => {
 
 Deno.test("extractYouTubeVideoId - random text returns null", () => {
   assertEquals(extractYouTubeVideoId("not a url at all"), null);
+});
+
+// Thumbnail fallback tests using fetch stubs
+
+function stubFetch(responses: Map<string, { ok: boolean; status: number; body: Uint8Array }>) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (input: string | URL | Request, _init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const stub = responses.get(url);
+    if (stub) {
+      return Promise.resolve(new Response(stub.body, { status: stub.status }));
+    }
+    return Promise.resolve(new Response("Not found", { status: 404 }));
+  };
+  return () => { globalThis.fetch = originalFetch; };
+}
+
+Deno.test("getYouTubeThumbnail - skips placeholder-sized live/maxres, uses hqdefault", async () => {
+  const smallPlaceholder = new Uint8Array(1000); // <5KB placeholder
+  const validImage = new Uint8Array(10000);      // >5KB real image
+  crypto.getRandomValues(validImage);
+
+  const responses = new Map([
+    ["https://img.youtube.com/vi/testid123/live.jpg", { ok: true, status: 200, body: smallPlaceholder }],
+    ["https://img.youtube.com/vi/testid123/maxresdefault.jpg", { ok: true, status: 200, body: smallPlaceholder }],
+    ["https://img.youtube.com/vi/testid123/hqdefault.jpg", { ok: true, status: 200, body: validImage }],
+  ]);
+
+  const restore = stubFetch(responses);
+  try {
+    const result = await getYouTubeThumbnail("testid123", "test-timestamp");
+    assertEquals(result.jpgFilename, "youtube-testid123-test-timestamp.jpg");
+    assertEquals(result.gifFilename, "youtube-testid123-test-timestamp.gif");
+  } finally {
+    restore();
+    // Clean up test files
+    await Deno.remove("youtube-snapshots/youtube-testid123-test-timestamp.jpg").catch(() => {});
+    await Deno.remove("youtube-snapshots/youtube-testid123-test-timestamp.gif").catch(() => {});
+  }
+});
+
+Deno.test("getYouTubeThumbnail - accepts small hqdefault without size check", async () => {
+  const smallButValid = new Uint8Array(2000); // <5KB but hqdefault should still be accepted
+  crypto.getRandomValues(smallButValid);
+
+  const responses = new Map([
+    ["https://img.youtube.com/vi/smallid/live.jpg", { ok: false, status: 404, body: new Uint8Array(0) }],
+    ["https://img.youtube.com/vi/smallid/maxresdefault.jpg", { ok: false, status: 404, body: new Uint8Array(0) }],
+    ["https://img.youtube.com/vi/smallid/hqdefault.jpg", { ok: true, status: 200, body: smallButValid }],
+  ]);
+
+  const restore = stubFetch(responses);
+  try {
+    const result = await getYouTubeThumbnail("smallid", "test-ts");
+    assertEquals(result.jpgFilename, "youtube-smallid-test-ts.jpg");
+  } finally {
+    restore();
+    await Deno.remove("youtube-snapshots/youtube-smallid-test-ts.jpg").catch(() => {});
+    await Deno.remove("youtube-snapshots/youtube-smallid-test-ts.gif").catch(() => {});
+  }
+});
+
+Deno.test("getYouTubeThumbnail - throws when all thumbnails fail", async () => {
+  const responses = new Map([
+    ["https://img.youtube.com/vi/failid/live.jpg", { ok: false, status: 404, body: new Uint8Array(0) }],
+    ["https://img.youtube.com/vi/failid/maxresdefault.jpg", { ok: false, status: 404, body: new Uint8Array(0) }],
+    ["https://img.youtube.com/vi/failid/hqdefault.jpg", { ok: false, status: 404, body: new Uint8Array(0) }],
+  ]);
+
+  const restore = stubFetch(responses);
+  try {
+    await assertRejects(
+      () => getYouTubeThumbnail("failid", "test-ts"),
+      Error,
+      "Failed to download any valid thumbnail",
+    );
+  } finally {
+    restore();
+  }
 });

--- a/youtube-snapshot.test.ts
+++ b/youtube-snapshot.test.ts
@@ -41,7 +41,7 @@ Deno.test("extractYouTubeVideoId - random text returns null", () => {
   assertEquals(extractYouTubeVideoId("not a url at all"), null);
 });
 
-// Thumbnail fallback tests using fetch stubs
+// Thumbnail fallback tests using fetch and Deno.Command stubs
 
 function stubFetch(responses: Map<string, { ok: boolean; status: number; body: Uint8Array }>) {
   const originalFetch = globalThis.fetch;
@@ -56,6 +56,26 @@ function stubFetch(responses: Map<string, { ok: boolean; status: number; body: U
   return () => { globalThis.fetch = originalFetch; };
 }
 
+// Stub Deno.Command so tests don't require ffmpeg to be installed
+function stubDenoCommand() {
+  const OriginalCommand = Deno.Command;
+  // deno-lint-ignore no-explicit-any
+  (Deno as any).Command = class {
+    constructor(_cmd: string, _opts?: Deno.CommandOptions) {}
+    output(): Promise<Deno.CommandOutput> {
+      return Promise.resolve({
+        success: true,
+        code: 0,
+        stdout: new Uint8Array(),
+        stderr: new Uint8Array(),
+        signal: null,
+      });
+    }
+  };
+  // deno-lint-ignore no-explicit-any
+  return () => { (Deno as any).Command = OriginalCommand; };
+}
+
 Deno.test("getYouTubeThumbnail - skips placeholder-sized live/maxres, uses hqdefault", async () => {
   const smallPlaceholder = new Uint8Array(1000); // <5KB placeholder
   const validImage = new Uint8Array(10000);      // >5KB real image
@@ -67,13 +87,15 @@ Deno.test("getYouTubeThumbnail - skips placeholder-sized live/maxres, uses hqdef
     ["https://img.youtube.com/vi/testid123/hqdefault.jpg", { ok: true, status: 200, body: validImage }],
   ]);
 
-  const restore = stubFetch(responses);
+  const restoreFetch = stubFetch(responses);
+  const restoreCommand = stubDenoCommand();
   try {
     const result = await getYouTubeThumbnail("testid123", "test-timestamp");
     assertEquals(result.jpgFilename, "youtube-testid123-test-timestamp.jpg");
     assertEquals(result.gifFilename, "youtube-testid123-test-timestamp.gif");
   } finally {
-    restore();
+    restoreFetch();
+    restoreCommand();
     // Clean up test files
     await Deno.remove("youtube-snapshots/youtube-testid123-test-timestamp.jpg").catch(() => {});
     await Deno.remove("youtube-snapshots/youtube-testid123-test-timestamp.gif").catch(() => {});
@@ -90,12 +112,14 @@ Deno.test("getYouTubeThumbnail - accepts small hqdefault without size check", as
     ["https://img.youtube.com/vi/smallid/hqdefault.jpg", { ok: true, status: 200, body: smallButValid }],
   ]);
 
-  const restore = stubFetch(responses);
+  const restoreFetch = stubFetch(responses);
+  const restoreCommand = stubDenoCommand();
   try {
     const result = await getYouTubeThumbnail("smallid", "test-ts");
     assertEquals(result.jpgFilename, "youtube-smallid-test-ts.jpg");
   } finally {
-    restore();
+    restoreFetch();
+    restoreCommand();
     await Deno.remove("youtube-snapshots/youtube-smallid-test-ts.jpg").catch(() => {});
     await Deno.remove("youtube-snapshots/youtube-smallid-test-ts.gif").catch(() => {});
   }

--- a/youtube-snapshot.test.ts
+++ b/youtube-snapshot.test.ts
@@ -49,7 +49,7 @@ function stubFetch(responses: Map<string, { ok: boolean; status: number; body: U
     const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
     const stub = responses.get(url);
     if (stub) {
-      return Promise.resolve(new Response(stub.body, { status: stub.status }));
+      return Promise.resolve(new Response(stub.body as unknown as BodyInit, { status: stub.status }));
     }
     return Promise.resolve(new Response("Not found", { status: 404 }));
   };

--- a/youtube-snapshot.ts
+++ b/youtube-snapshot.ts
@@ -12,6 +12,7 @@ interface Console {
 const PORT = parseInt(Deno.env.get("PORT") || "3000");
 const PUBLIC_URL = Deno.env.get("PUBLIC_URL") || `http://localhost:${PORT}`;
 const SNAPSHOTS_DIR = "youtube-snapshots";
+const YT_COOKIES_FILE = Deno.env.get("YT_COOKIES_FILE") || "";
 
 // Ensure snapshots directory exists
 try {
@@ -56,20 +57,36 @@ async function takeYouTubeSnapshot(videoUrl: string): Promise<{jpgFilename: stri
     try {
         // Use yt-dlp to download a short segment of the video
         console.log('Downloading video segment using yt-dlp');
+        const ytdlpArgs = [
+            '--format', 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best',
+            '--output', tempVideoFilename,
+            '--downloader', 'ffmpeg',
+            '--downloader-args', `ffmpeg:-t ${GIF_CONFIG.duration + 2}`,
+            '--force-overwrites',
+            '--ignore-no-formats-error',
+            '--ignore-errors',
+            '--retries', '3',
+            '--fragment-retries', '3',
+            '--socket-timeout', '15',
+            '--extractor-args', 'youtube:player_client=web_creator,mediaconnect',
+            '--user-agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+        ];
+
+        // Add cookies file if configured
+        if (YT_COOKIES_FILE) {
+            try {
+                await Deno.stat(YT_COOKIES_FILE);
+                ytdlpArgs.push('--cookies', YT_COOKIES_FILE);
+                console.log('Using cookies file:', YT_COOKIES_FILE);
+            } catch {
+                console.warn('Cookies file not found:', YT_COOKIES_FILE);
+            }
+        }
+
+        ytdlpArgs.push(videoUrl);
+
         const ytdlp = new Deno.Command('yt-dlp', {
-            args: [
-                '--format', 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best',
-                '--output', tempVideoFilename,
-                '--downloader', 'ffmpeg',
-                '--downloader-args', `ffmpeg:-t ${GIF_CONFIG.duration + 2}`,
-                '--force-overwrites',
-                '--ignore-no-formats-error',
-                '--ignore-errors',
-                '--retries', '3',
-                '--fragment-retries', '3',
-                '--socket-timeout', '15',
-                videoUrl
-            ],
+            args: ytdlpArgs,
             stderr: "piped",
             stdout: "piped"
         });
@@ -164,29 +181,43 @@ async function getYouTubeThumbnail(videoId: string, timestamp: string): Promise<
     const gifFilename = `youtube-${videoId}-${timestamp}.gif`;
     
     // Try to download the thumbnail
+    // YouTube returns HTTP 200 with a small default placeholder for missing thumbnails,
+    // so we validate that the image is large enough to be a real thumbnail (>5KB).
+    const MIN_THUMBNAIL_SIZE = 5000;
     let response;
-    try {
-        // Try live thumbnail first
-        response = await fetch(thumbnailUrl);
-        if (!response.ok) {
-            console.log('Live thumbnail not available, trying maxresdefault');
-            response = await fetch(fallbackThumbnailUrl);
-            
+    let imageData: Uint8Array | null = null;
+
+    const thumbnailUrls = [
+        { url: thumbnailUrl, label: 'live' },
+        { url: fallbackThumbnailUrl, label: 'maxresdefault' },
+        { url: finalFallbackUrl, label: 'hqdefault' },
+    ];
+
+    for (const { url: thumbUrl, label } of thumbnailUrls) {
+        try {
+            response = await fetch(thumbUrl);
             if (!response.ok) {
-                console.log('Maxres thumbnail not available, trying hqdefault');
-                response = await fetch(finalFallbackUrl);
-                
-                if (!response.ok) {
-                    throw new Error('Failed to download any thumbnail');
-                }
+                console.log(`${label} thumbnail returned HTTP ${response.status}, skipping`);
+                continue;
             }
+            const data = new Uint8Array(await response.arrayBuffer());
+            if (data.length < MIN_THUMBNAIL_SIZE) {
+                console.log(`${label} thumbnail too small (${data.length} bytes), likely a placeholder`);
+                continue;
+            }
+            console.log(`Using ${label} thumbnail (${data.length} bytes)`);
+            imageData = data;
+            break;
+        } catch (e) {
+            console.log(`${label} thumbnail fetch failed:`, e instanceof Error ? e.message : String(e));
         }
-    } catch (error) {
-        throw new Error(`Failed to fetch YouTube thumbnail: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    if (!imageData) {
+        throw new Error('Failed to download any valid thumbnail');
     }
     
     // Write the downloaded thumbnail as JPG
-    const imageData = new Uint8Array(await response.arrayBuffer());
     await Deno.writeFile(join(SNAPSHOTS_DIR, jpgFilename), imageData);
     
     // Create a simple static GIF from the JPG

--- a/youtube-snapshot.ts
+++ b/youtube-snapshot.ts
@@ -75,11 +75,21 @@ async function takeYouTubeSnapshot(videoUrl: string): Promise<{jpgFilename: stri
         // Add cookies file if configured
         if (YT_COOKIES_FILE) {
             try {
-                await Deno.stat(YT_COOKIES_FILE);
-                ytdlpArgs.push('--cookies', YT_COOKIES_FILE);
-                console.log('Using cookies file:', YT_COOKIES_FILE);
-            } catch {
-                console.warn('Cookies file not found:', YT_COOKIES_FILE);
+                const stat = await Deno.stat(YT_COOKIES_FILE);
+                if (stat.isFile) {
+                    ytdlpArgs.push('--cookies', YT_COOKIES_FILE);
+                    console.log('Using cookies file:', YT_COOKIES_FILE);
+                } else {
+                    console.warn('Cookies path is not a file, skipping --cookies:', YT_COOKIES_FILE);
+                }
+            } catch (error) {
+                if (error instanceof Deno.errors.NotFound) {
+                    console.warn('Cookies file not found:', YT_COOKIES_FILE);
+                } else if (error instanceof Deno.errors.PermissionDenied) {
+                    console.warn('Cookies file is not readable due to permission issues:', YT_COOKIES_FILE);
+                } else {
+                    console.warn('Failed to access cookies file:', YT_COOKIES_FILE, error);
+                }
             }
         }
 
@@ -170,8 +180,8 @@ async function takeYouTubeSnapshot(videoUrl: string): Promise<{jpgFilename: stri
     }
 }
 
-// Function to get YouTube thumbnail as fallback
-async function getYouTubeThumbnail(videoId: string, timestamp: string): Promise<{jpgFilename: string, gifFilename: string}> {
+// Function to get YouTube thumbnail as fallback (exported for testing)
+export async function getYouTubeThumbnail(videoId: string, timestamp: string): Promise<{jpgFilename: string, gifFilename: string}> {
     // Use live thumbnail URL which updates more frequently
     const thumbnailUrl = `https://img.youtube.com/vi/${videoId}/live.jpg`;
     const fallbackThumbnailUrl = `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`;
@@ -180,28 +190,28 @@ async function getYouTubeThumbnail(videoId: string, timestamp: string): Promise<
     const jpgFilename = `youtube-${videoId}-${timestamp}.jpg`;
     const gifFilename = `youtube-${videoId}-${timestamp}.gif`;
     
-    // Try to download the thumbnail
-    // YouTube returns HTTP 200 with a small default placeholder for missing thumbnails,
-    // so we validate that the image is large enough to be a real thumbnail (>5KB).
+    // Try to download the thumbnail.
+    // YouTube's live.jpg and maxresdefault.jpg return HTTP 200 with a tiny default
+    // placeholder (~1-2KB) when the real thumbnail doesn't exist. hqdefault.jpg
+    // always exists but can be legitimately small, so we skip the size check for it.
     const MIN_THUMBNAIL_SIZE = 5000;
-    let response;
     let imageData: Uint8Array | null = null;
 
     const thumbnailUrls = [
-        { url: thumbnailUrl, label: 'live' },
-        { url: fallbackThumbnailUrl, label: 'maxresdefault' },
-        { url: finalFallbackUrl, label: 'hqdefault' },
+        { url: thumbnailUrl, label: 'live', checkSize: true },
+        { url: fallbackThumbnailUrl, label: 'maxresdefault', checkSize: true },
+        { url: finalFallbackUrl, label: 'hqdefault', checkSize: false },
     ];
 
-    for (const { url: thumbUrl, label } of thumbnailUrls) {
+    for (const { url: thumbUrl, label, checkSize } of thumbnailUrls) {
         try {
-            response = await fetch(thumbUrl);
+            const response = await fetch(thumbUrl);
             if (!response.ok) {
                 console.log(`${label} thumbnail returned HTTP ${response.status}, skipping`);
                 continue;
             }
             const data = new Uint8Array(await response.arrayBuffer());
-            if (data.length < MIN_THUMBNAIL_SIZE) {
+            if (checkSize && data.length < MIN_THUMBNAIL_SIZE) {
                 console.log(`${label} thumbnail too small (${data.length} bytes), likely a placeholder`);
                 continue;
             }


### PR DESCRIPTION
## Summary
This PR enhances YouTube snapshot functionality by adding support for authenticated requests via cookies and implementing more robust thumbnail retrieval with better fallback handling.

## Key Changes

- **YouTube Cookies Support**: Added `YT_COOKIES_FILE` environment variable to allow passing authentication cookies to yt-dlp, enabling downloads of age-restricted or region-locked content
  - Cookies file is optional and validated before use
  - Includes helpful logging when cookies are configured
  - Updated Dockerfile with documentation on how to mount cookies file

- **Improved Thumbnail Fallback Logic**: Refactored thumbnail retrieval to be more resilient
  - Implements a loop-based approach to try multiple thumbnail URLs in sequence (live → maxresdefault → hqdefault)
  - Adds validation to detect YouTube's placeholder images (< 5KB) and skip them
  - Better error handling with per-URL logging instead of failing on first error
  - Clearer distinction between HTTP errors and placeholder detection

- **Enhanced yt-dlp Arguments**: Refactored command-line arguments into a structured array for better maintainability
  - Added YouTube-specific extractor arguments for improved compatibility
  - Added custom User-Agent header for better request handling
  - Arguments are now easier to modify and extend

## Implementation Details

- The cookies file validation uses `Deno.stat()` to check existence before passing to yt-dlp
- Thumbnail size validation (5KB minimum) prevents using YouTube's default placeholder images that are returned with HTTP 200
- The thumbnail fallback loop tries each URL independently, allowing graceful degradation when some sources are unavailable

https://claude.ai/code/session_01JmcTcEHCSWVksHMFgaC4vk